### PR TITLE
Pointed Download Link to download.visioneval.org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,9 @@ author:
   name:           'VisionEval'
   url:            https://github.com/visioneval
 
+exclude:          [category/3download.md]
 paginate:         5
+
 # paginate_path:    '/page:num'
                     # Or '/blog/page:num' if you want to move your index pages
 

--- a/_includes/custom-nav-links.html
+++ b/_includes/custom-nav-links.html
@@ -1,1 +1,2 @@
 <!-- Optional additional links to insert in sidebar nav -->
+<a class="category-link" href="https://download.visioneval.org">Download</a>


### PR DESCRIPTION
Here is the minimal set of changes to enable the Download link pointing at download.visioneval.org.  Try it out and merge "new-download" into master if you think it's working.  Otherwise let me know and we'll try again.

There's a live demo at visioneval.jeremyraw.com (redirected Download link).  Also download.visioneval.org itself has been hacked to look like a seamless element of the base site.  I'm going to continue to fix download.visioneval.org.